### PR TITLE
Clarify the Parquet FileMetadata value formatting (UTF8 string, JSON-encoded)

### DIFF
--- a/format-specs/geoparquet.md
+++ b/format-specs/geoparquet.md
@@ -82,9 +82,8 @@ of the spec may support alternative encodings.
 
 ## TODO
 
-1. Figure out what parquet allows for metadata. Might be forced to use bytes?
-2. Do we want to include the [bounding box](https://github.com/geopandas/geo-arrow-spec/blob/dac0d4fe28ad2871ea1042aa72ea8d6b236e2fa8/metadata.md#bounding-boxes) metadata? Should probably explain how it would be used as partitions for individual files.
-3. What all is required on the column metadata?
+1. Do we want to include the [bounding box](https://github.com/geopandas/geo-arrow-spec/blob/dac0d4fe28ad2871ea1042aa72ea8d6b236e2fa8/metadata.md#bounding-boxes) metadata? Should probably explain how it would be used as partitions for individual files.
+2. What all is required on the column metadata?
 
 
 [parquet]: https://parquet.apache.org/

--- a/format-specs/geoparquet.md
+++ b/format-specs/geoparquet.md
@@ -20,7 +20,7 @@ geoparquet files include additional metadata at two levels:
 1. File metadata indicating things like the version of this specification used
 2. Column metadata with additional metadata for each geometry column
 
-These are both stored under a "geo" key in the parquet metadata.
+These are both stored under a "geo" key in the parquet metadata as a JSON-encoded UTF-8 string.
 
 ## File metadata
 


### PR DESCRIPTION
Closes #7

The keys and values of Parquet key-value metadata is required to be a string. See the definition in the thrift spec at https://github.com/apache/parquet-format/blob/54e53e5d7794d383529dd30746378f19a12afd58/src/main/thrift/parquet.thrift#L680-L683. In thrift, a `string` is defined as "A text string encoded using UTF-8 encoding". 

Our current specification of the geo metadata should be fully compliant to this, as it only includes string fields and values, and the whole is JSON encoded, so still a valid UTF8 string. 

While removing the TODO item about this, I realized we currently actually don't really mention how the key-values are stored (JSON-encoded string, at least that's what we currently do). So I added a sentence about that to clarify this. This is documenting the current status, although it could maybe also use a broader discussion if we are happy with the JSON encoding (-> opened https://github.com/opengeospatial/cdw-geo/issues/7).

