### PR TITLE
More explicitly mention the metadata is stored in the parquet FileMetaData

### DIFF
--- a/format-specs/geoparquet.md
+++ b/format-specs/geoparquet.md
@@ -20,7 +20,7 @@ geoparquet files include additional metadata at two levels:
 1. File metadata indicating things like the version of this specification used
 2. Column metadata with additional metadata for each geometry column
 
-These are both stored under a "geo" key in the parquet metadata as a JSON-encoded UTF-8 string.
+These are both stored under a "geo" key in the parquet metadata (the [`FileMetaData::key_value_metadata`](https://github.com/apache/parquet-format#metadata)) as a JSON-encoded UTF-8 string.
 
 ## File metadata
 


### PR DESCRIPTION
Can't hurt to be more explicit (since there are multiple places in the full parquet metadata structure where custom metadata can be put)