### PR TITLE
Validator updates

### DIFF
--- a/validator/README.md
+++ b/validator/README.md
@@ -5,5 +5,12 @@ Based on [JSON Schema](https://json-schema.org/).
 ## Python
 
 ```
-./validate.py ../examples/example.parquet
+python validate.py ../examples/example.parquet
+python validate.py https://storage.googleapis.com/open-geodata/linz-examples/nz-buildings-outlines.parquet
 ```
+
+The validator also supports remote files.
+
+- `http://` or `https://`: no further configuration is needed.
+- `s3://`: `s3fs` needs to be installed (run `pip install s3fs`) and you may need to set environment variables. Refer [here](https://s3fs.readthedocs.io/en/latest/#credentials) for how to define credentials.
+- `gs://`: `gcsfs` needs to be installed (run `pip install gcsfs`). By default, `gcsfs` will attempt to use your default gcloud credentials or, attempt to get credentials from the google metadata service, or fall back to anonymous access.

--- a/validator/environment.yml
+++ b/validator/environment.yml
@@ -4,4 +4,5 @@ channels:
 dependencies:
   - python=3.9*
   - pyarrow
-  - jsonschema
+  - jsonschema>=4
+  - fsspec

--- a/validator/schema.json
+++ b/validator/schema.json
@@ -1,88 +1,76 @@
 {
-    "title": "GeoParquet",
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "description": "Parquet metadata included in the geo field.",
-    "properties": {
-        "version": {
-            "type": "string",
-            "pattern": "^0\\.1\\.[0-9]+$",
-            "description": "The version of the geoparquet metadata standard used when writing."
-        },
-        "primary_column": {
-            "type": "string",
-            "description": "The name of the 'primary' geometry column."
-        },
-        "columns": {
-            "type": "object",
-            "description": "Metadata about geometry columns, with each key is the name of a geometry column in the table.",
-            "patternProperties": {
-                ".*": {
-                    "type": "object",
-                    "properties": {
-                        "crs": {
-                            "type": "string",
-                            "description": "WKT2 representing the Coordinate Reference System (CRS) of the geometry."
-                        },
-                        "encoding": {
-                            "type": "string",
-                            "enum": [
-                                "WKB"
-                            ],
-                            "description": "Name of the geometry encoding format. Currently only 'WKB' is supported."
-                        },
-                        "edges": {
-                            "type": "string",
-                            "enum": [
-                                "planar",
-                                "spherical"
-                            ],
-                            "description": "Name of the coordinate system for the edges. Must be one of 'planar' or 'spherical'. The default value is 'planar'."
-                        },
-                        "bbox": {
-                            "type": "array",
-                            "description": "Bounding Box of the geometries in the file, formatted according to RFC 7946, section 5.",
-                            "items": [
-                                {
-                                    "type": "number",
-                                    "minimum": -180,
-                                    "maximum": 180,
-                                    "description": "The westmost constant longitude line that bounds the rectangle (xmin)."
-                                },
-                                {
-                                    "type": "number",
-                                    "minimum": -90,
-                                    "maximum": 90,
-                                    "description": "The minimum constant latitude line that bounds the rectangle (ymin)."
-                                },
-                                {
-                                    "type": "number",
-                                    "minimum": -180,
-                                    "maximum": 180,
-                                    "description": "The eastmost constant longitude line that bounds the rectangle (xmax)."
-                                },
-                                {
-                                    "type": "number",
-                                    "minimum": -90,
-                                    "maximum": 90,
-                                    "description": "The maximum constant latitude line that bounds the rectangle (ymax)."
-                                }
-                            ]
-                        }
-                    },
-                    "additionalProperties": true,
-                    "required": [
-                        "crs",
-                        "encoding"
-                    ]
-                }
-            }
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GeoParquet",
+  "type": "object",
+  "description": "Parquet metadata included in the geo field.",
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^0\\.1\\.[0-9]+$",
+      "description": "The version of the geoparquet metadata standard used when writing."
     },
-    "additionalProperties": true,
-    "required": [
-        "version",
-        "primary_column",
-        "columns"
-    ]
+    "primary_column": {
+      "type": "string",
+      "description": "The name of the 'primary' geometry column."
+    },
+    "columns": {
+      "type": "object",
+      "description": "Metadata about geometry columns, with each key is the name of a geometry column in the table.",
+      "patternProperties": {
+        ".*": {
+          "type": "object",
+          "properties": {
+            "crs": {
+              "type": "string",
+              "description": "WKT2 representing the Coordinate Reference System (CRS) of the geometry."
+            },
+            "encoding": {
+              "type": "string",
+              "enum": ["WKB"],
+              "description": "Name of the geometry encoding format. Currently only 'WKB' is supported."
+            },
+            "edges": {
+              "type": "string",
+              "enum": ["planar", "spherical"],
+              "description": "Name of the coordinate system for the edges. Must be one of 'planar' or 'spherical'. The default value is 'planar'."
+            },
+            "bbox": {
+              "type": "array",
+              "description": "Bounding Box of the geometries in the file, formatted according to RFC 7946, section 5.",
+              "items": [
+                {
+                  "type": "number",
+                  "minimum": -180,
+                  "maximum": 180,
+                  "description": "The westmost constant longitude line that bounds the rectangle (xmin)."
+                },
+                {
+                  "type": "number",
+                  "minimum": -90,
+                  "maximum": 90,
+                  "description": "The minimum constant latitude line that bounds the rectangle (ymin)."
+                },
+                {
+                  "type": "number",
+                  "minimum": -180,
+                  "maximum": 180,
+                  "description": "The eastmost constant longitude line that bounds the rectangle (xmax)."
+                },
+                {
+                  "type": "number",
+                  "minimum": -90,
+                  "maximum": 90,
+                  "description": "The maximum constant latitude line that bounds the rectangle (ymax)."
+                }
+              ]
+            }
+          },
+          "additionalProperties": true,
+          "required": ["crs", "encoding"]
+        }
+      }
+    }
+  },
+  "additionalProperties": true,
+  "required": ["version", "primary_column", "columns"]
 }

--- a/validator/validate.py
+++ b/validator/validate.py
@@ -1,11 +1,50 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
-import sys
 import json
-import pyarrow.parquet as pq
-
+import sys
 from pathlib import Path
+from pprint import pprint
+from urllib.parse import urlparse
+
+import pyarrow.parquet as pq
+from fsspec import AbstractFileSystem
+from fsspec.implementations.local import LocalFileSystem
 from jsonschema.validators import Draft7Validator
+from pyarrow.fs import FSSpecHandler, PyFileSystem
+
+
+class MetadataError(ValueError):
+    pass
+
+
+def choose_fsspec_fs(url_or_path: str) -> AbstractFileSystem:
+    """Choose fsspec filesystem by sniffing input url"""
+    parsed = urlparse(url_or_path)
+
+    if parsed.scheme.startswith("http"):
+        from fsspec.implementations.http import HTTPFileSystem
+
+        return HTTPFileSystem()
+
+    if parsed.scheme == "s3":
+        from s3fs import S3FileSystem
+
+        return S3FileSystem()
+
+    if parsed.scheme == "gs":
+        from gcsfs import GCSFileSystem
+
+        return GCSFileSystem()
+
+    # TODO: Add Azure
+    return LocalFileSystem()
+
+
+def load_parquet_schema(url_or_path: str) -> pq.ParquetSchema:
+    """Load schema from local or remote Parquet file"""
+    fsspec_fs = choose_fsspec_fs(url_or_path)
+    pyarrow_fs = PyFileSystem(FSSpecHandler(fsspec_fs))
+    return pq.read_schema(pyarrow_fs.open_input_file(url_or_path))
 
 
 def validate_geoparquet(input_file):
@@ -14,7 +53,13 @@ def validate_geoparquet(input_file):
     with open(schema_path) as f:
         schema = json.load(f)
 
-    metadata = json.loads(pq.read_schema(input_file).metadata[b"geo"])
+    parquet_schema = load_parquet_schema(input_file)
+    if b"geo" not in parquet_schema.metadata:
+        raise MetadataError("Parquet file schema does not have 'geo' key")
+
+    metadata = json.loads(parquet_schema.metadata[b"geo"])
+    print("Metadata loaded from file:")
+    pprint(metadata)
 
     errors = Draft7Validator(schema).iter_errors(metadata)
 
@@ -28,7 +73,7 @@ def validate_geoparquet(input_file):
             print(f"          INFO: {error.schema['description']}")
 
     # Extra errors
-    if (metadata["primary_column"] not in metadata["columns"]):
+    if metadata["primary_column"] not in metadata["columns"]:
         valid = False
         print("- [ERROR] $.primary_column: must be in $.columns")
 
@@ -36,7 +81,8 @@ def validate_geoparquet(input_file):
         print("This is a valid GeoParquet file.")
     else:
         print("This is an invalid GeoParquet file.")
+        exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     validate_geoparquet(sys.argv[1])

--- a/validator/validate.py
+++ b/validator/validate.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 
 import pyarrow.parquet as pq
 from fsspec import AbstractFileSystem
+from fsspec.implementations.http import HTTPFileSystem
 from fsspec.implementations.local import LocalFileSystem
 from jsonschema.validators import Draft7Validator
 from pyarrow.fs import FSSpecHandler, PyFileSystem
@@ -22,8 +23,6 @@ def choose_fsspec_fs(url_or_path: str) -> AbstractFileSystem:
     parsed = urlparse(url_or_path)
 
     if parsed.scheme.startswith("http"):
-        from fsspec.implementations.http import HTTPFileSystem
-
         return HTTPFileSystem()
 
     if parsed.scheme == "s3":


### PR DESCRIPTION
### Change list

- Add support for remote files via `http://`, `https://`, `s3://`, and `gs://` protocols.
- Document in the `README.md` that `s3fs` needs to be installed to load `s3://` files and `gcsfs` needs to be installed to load `gs://` files.
- Specify in the `environment.yml` file that jsonschema v4 is required. The error that @cholmes hit [here](https://github.com/opengeospatial/geoparquet/pull/58#issuecomment-1095529120) is likely because he had jsonschema v3 installed.
- Raise error if the Parquet file metadata has no `geo` key
- Don't suggest that users call `./validate.py`. Especially in conjunction with `#!/usr/bin/python3`, that would've always used the _system_ Python executable, which is both bad practice and would likely lead to confusion why Python packages weren't being found. Instead, suggesting `python validate.py` ensures that the python in the user's `PATH` will be used.
- Change the shebang from `#!/usr/bin/python3` to `#!/usr/bin/env python3`, which ensures that if the user _does_ call `./validate.py`, then most often the `python` in the user's `PATH` will be found, instead of always using the system Python.
- Use 2-space indenting for the `schema.json` file in line with the [STAC spec's schema files](https://github.com/radiantearth/stac-spec/blob/master/item-spec/json-schema/item.json) for readability. I can back this out of this PR if preferred. Ideally we'll add a lint step to format the schema file.