### PR TITLE
Example: Use `total_bounds` for finding bounds of GeoDataFrame

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -32,7 +32,7 @@ metadata = {
             "geometry_type": ["Polygon", "MultiPolygon"],
             "crs": df.crs.to_wkt(pyproj.enums.WktVersion.WKT2_2019_SIMPLIFIED),
             "edges": "planar",
-            "bbox": [round(x, 4) for x in df.geometry.unary_union.bounds],
+            "bbox": [round(x, 4) for x in df.total_bounds],
         },
     },
 }


### PR DESCRIPTION
I expect `GeoDataFrame.total_bounds` should be faster than `GeoDataFrame.geometry.unary_union.bounds`, because the latter creates a new geometry object while the former takes the bounds of each geometry and sums them up? This is in fact [what the GeoPandas writer does](https://github.com/geopandas/geopandas/blob/3abc6a79cacfe5b18299074fc3ed9ab993e80c2f/geopandas/io/arrow.py#L62) 🙂 .

@jorisvandenbossche can you confirm?

If these are equivalent then maybe better to use `total_bounds` for the example we show publicly 🙂 .

Noted on twitter: https://twitter.com/dkwiens/status/1520130124540129280