### PR TITLE
Allow for more than 3 dimensions in the bbox

### DIFF
--- a/format-specs/schema.json
+++ b/format-specs/schema.json
@@ -65,20 +65,9 @@
               "type": "array",
               "description": "Bounding Box of the geometries in the file, formatted according to RFC 7946, section 5.",
               "items": {
-                "type": "number"
-              },
-              "oneOf": [
-                {
-                  "description": "2D bbox consisting of (xmin, ymin, xmax, ymax)",
-                  "minItems": 4,
-                  "maxItems": 4
-                },
-                {
-                  "description": "3D bbox consisting of (xmin, ymin, zmin, xmax, ymax, zmax)",
-                  "minItems": 6,
-                  "maxItems": 6
-                }
-              ]
+                "type": "number",
+                "minItems": 4
+              }
             },
             "epoch": {
               "type": "number",


### PR DESCRIPTION
The GeoJSON spec recommends 2 or 3 dimensions, but does not forbid geometries that have more.  See https://www.rfc-editor.org/rfc/rfc7946#section-3.1.1.

In addition, the `bbox` length is `2*n` where `n` is the number of dimensions.  See https://www.rfc-editor.org/rfc/rfc7946#section-5.