### PR TITLE
Clarify geographic vs non-geographic bbox values

### DIFF
--- a/format-specs/geoparquet.md
+++ b/format-specs/geoparquet.md
@@ -168,11 +168,18 @@ Bounding boxes are used to help define the spatial extent of each geometry colum
 Implementations of this schema may choose to use those bounding boxes to filter
 partitions (files) of a partitioned dataset.
 
-The bbox, if specified, must be encoded with an array containing the minimum
-and maximum values of each dimension: `[<xmin>, <ymin>, <xmax>, <ymax>]` for 2D
-or `[<xmin>, <ymin>, <zmin>, <xmax>, <ymax>, <zmax>]` for 3D geometries.
-This follows the GeoJSON specification ([RFC 7946, section 5](https://tools.ietf.org/html/rfc7946#section-5)),
-but is expressed in the same CRS as the geometry.
+The bbox, if specified, must be encoded with an array representing the range of values for each dimension in the
+geometry coordinates.  For geometries in a geographic coordinate reference system, longitude and latitude values are
+listed for the most southwesterly coordinate followed by values for the most northeasterly coordinate.  This follows the
+GeoJSON specification ([RFC 7946, section 5](https://tools.ietf.org/html/rfc7946#section-5)), which also describes how
+to represent the bbox for a set of geometries that cross the antimeridian.
+
+For non-geographic coordinate reference systems, the items in the bbox are minimum values for each dimension followed by
+maximum values for each dimension.  For example, given geometries that have coordinates with two dimensions, the bbox
+would have the form `[<xmin>, <ymin>, <xmax>, <ymax>]`.  For three dimensions, the bbox would have the form
+`[<xmin>, <ymin>, <zmin>, <xmax>, <ymax>, <zmax>]`.
+
+The bbox values are in the same coordinate reference system as the geometry.
 
 ### Additional information
 


### PR DESCRIPTION
This updates the language about bbox to align with GeoJSON for geographic coordinates and give min/max examples for non-geographic coordinates.

Fixes #112.

(One thing to note - the GeoJSON spec is a bit misleading in saying that the bbox has values for _"all axes of the most southwesterly point followed by all axes of the more northeasterly point."_  What it means is that the value for $i_0$ is the most westerly, the value for $i_1$ is the most southerly, the value for $i_n$ is the most easterly, and the value for $i_{n+1}$ is the most northerly.  The values for all other items are the minima followed by the maxima.  The way the spec reads, it sounds like the third item of a bbox for geometries with a z would be the z value for the most southwesterly point.  Instead it should be the minimum z value for all coordinates.  I'll bring this up on the GeoJSON list and submit an errata report if others agree.)