### PR TITLE
schema.json: update reference to projjson schema to v0.5

### DIFF
--- a/format-specs/schema.json
+++ b/format-specs/schema.json
@@ -37,7 +37,7 @@
             "crs": {
               "oneOf": [
                 {
-                  "$ref": "https://proj.org/schemas/v0.4/projjson.schema.json"
+                  "$ref": "https://proj.org/schemas/v0.5/projjson.schema.json"
                 },
                 {
                   "type": "null"


### PR DESCRIPTION
Latest released is v0.5 (cf https://proj.org/specifications/projjson.html). It is fully backward compatible with previous versions.