### PR TITLE
Require minimum length of 1 for primary_geometry #129

### DIFF
--- a/format-specs/geoparquet.md
+++ b/format-specs/geoparquet.md
@@ -38,7 +38,7 @@ All file-level metadata should be included under the "geo" key in the parquet me
 |     Field Name     |  Type  |                             Description                              |
 | ------------------ | ------ | -------------------------------------------------------------------- |
 | version     		 | string | **REQUIRED** The version of the GeoParquet metadata standard used when writing. |
-| primary_column     | string | **REQUIRED** The name of the "primary" geometry column with a minimum length of 1. |
+| primary_column     | string | **REQUIRED** The name of the "primary" geometry column. |
 | columns            | object<key, [Column Metadata](#column-metadata)> | **REQUIRED** Metadata about geometry columns. Each key is the name of a geometry column in the table. |
 
 At this level, additional implementation-specific fields (e.g. library name) are allowed, and thus readers should be robust in ignoring those.

--- a/format-specs/geoparquet.md
+++ b/format-specs/geoparquet.md
@@ -37,9 +37,9 @@ All file-level metadata should be included under the "geo" key in the parquet me
 
 |     Field Name     |  Type  |                             Description                              |
 | ------------------ | ------ | -------------------------------------------------------------------- |
-| version     		 | string | **REQUIRED** The version of the GeoParquet metadata standard used when writing.   |
-| primary_column     | string | **REQUIRED** The name of the "primary" geometry column.                |
-| columns            | object<key, [Column Metadata](#column-metadata)> | **REQUIRED** Metadata about geometry columns, with each key is the name of a geometry column in the table. |
+| version     		 | string | **REQUIRED** The version of the GeoParquet metadata standard used when writing. |
+| primary_column     | string | **REQUIRED** The name of the "primary" geometry column with a minimum length of 1. |
+| columns            | object<key, [Column Metadata](#column-metadata)> | **REQUIRED** Metadata about geometry columns. Each key is the name of a geometry column in the table. |
 
 At this level, additional implementation-specific fields (e.g. library name) are allowed, and thus readers should be robust in ignoring those.
 

--- a/format-specs/schema.json
+++ b/format-specs/schema.json
@@ -11,6 +11,7 @@
     },
     "primary_column": {
       "type": "string",
+      "minLength": 1,
       "description": "The name of the 'primary' geometry column."
     },
     "columns": {


### PR DESCRIPTION
Require a minimum length of 1 for the primary_geometry as otherwise it can be empty.
+ some minor test/formatting changes.

Partially solves #129.