### PR TITLE
Clean-up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Anyone is welcome to join us, by building implementations, trying it out, giving
 Initial work started in the [geo-arrow-spec](https://github.com/geopandas/geo-arrow-spec/) GeoPandas repository, and that will continue on
 Arrow work in a compatible way, with this specification focused solely on Parquet.
 
+- [**Specification**](format-specs/geoparquet.md)
+- [JSON Schema](format-specs/schema.json)
+- [Examples](examples/)
+- [Validator](validator/)
+
 ## Goals
 
 There are a few core goals driving the initial development.

--- a/format-specs/geoparquet.md
+++ b/format-specs/geoparquet.md
@@ -2,12 +2,16 @@
 
 ## Overview
 
-The [Apache Parquet][parquet] provides a standardized open-source columnar storage format. This specification defines how geospatial data
+The [Apache Parquet](https://parquet.apache.org/) provides a standardized open-source columnar storage format. This specification defines how geospatial data
 should be stored in parquet format, including the representation of geometries and the required additional metadata.
+
+**Additional resources:**
+* [Examples](../examples/)
+* [JSON Schema](schema.json)
 
 ## Version
 
-This is version 0.4.0 of the GeoParquet specification.
+This is version 0.5.0-dev of the GeoParquet specification.
 
 ## Geometry columns
 
@@ -16,11 +20,11 @@ See the [encoding](#encoding) section below for more details.
 
 ### Nesting
 
-Geometry columns must be at the root of the schema.  A geometry cannot be a group field or nested in a group.  In practice, this means that when writing to GeoParquet from another format, geometries cannot be contained in complex or nested types such as structs, lists, arrays, or map types.
+Geometry columns must be at the root of the schema. A geometry cannot be a group field or nested in a group. In practice, this means that when writing to GeoParquet from another format, geometries cannot be contained in complex or nested types such as structs, lists, arrays, or map types.
 
 ### Repetition
 
-The repetition for all geometry columns must be "required" (exactly one) or "optional" (zero or one).  A geometry column must not be repeated.  A GeoParquet file may have multiple geometry columns with different names, but those geometry columns cannot be repeated.
+The repetition for all geometry columns must be "required" (exactly one) or "optional" (zero or one). A geometry column must not be repeated. A GeoParquet file may have multiple geometry columns with different names, but those geometry columns cannot be repeated.
 
 ## Metadata
 
@@ -29,7 +33,7 @@ GeoParquet files include additional metadata at two levels:
 1. File metadata indicating things like the version of this specification used
 2. Column metadata with additional metadata for each geometry column
 
-These are both stored under a "geo" key in the parquet metadata (the [`FileMetaData::key_value_metadata`](https://github.com/apache/parquet-format#metadata)) as a JSON-encoded UTF-8 string.
+These are both stored under a `geo` key in the parquet metadata (the [`FileMetaData::key_value_metadata`](https://github.com/apache/parquet-format#metadata)) as a JSON-encoded UTF-8 string.
 
 ## File metadata
 
@@ -37,9 +41,9 @@ All file-level metadata should be included under the "geo" key in the parquet me
 
 |     Field Name     |  Type  |                             Description                              |
 | ------------------ | ------ | -------------------------------------------------------------------- |
-| version     		   | string | **REQUIRED** The version of the GeoParquet metadata standard used when writing. |
-| primary_column     | string | **REQUIRED** The name of the "primary" geometry column.              |
-| columns            | object\<string, [Column Metadata](#column-metadata)> | **REQUIRED** Metadata about geometry columns. Each key is the name of a geometry column in the table. |
+| version     		 | string | **REQUIRED.** The version of the GeoParquet metadata standard used when writing. |
+| primary_column     | string | **REQUIRED.** The name of the "primary" geometry column.             |
+| columns            | object\<string, [Column Metadata](#column-metadata)> | **REQUIRED.** Metadata about geometry columns. Each key is the name of a geometry column in the table. |
 
 At this level, additional implementation-specific fields (e.g. library name) are allowed, and thus readers should be robust in ignoring those.
 
@@ -52,7 +56,7 @@ but have a default geometry used for geospatial operations.
 
 #### version
 
-Version of the GeoParquet spec used, currently 0.4.0
+Version of the GeoParquet spec used, currently 0.5.0-dev
 
 ### Column metadata
 
@@ -60,13 +64,13 @@ Each geometry column in the dataset must be included in the columns field above 
 
 | Field Name     | Type         | Description |
 | -------------- | ------------ | ----------- |
-| encoding       | string       | **REQUIRED** Name of the geometry encoding format. Currently only `"WKB"` is supported. |
-| geometry_types | \[string]    | **REQUIRED** The geometry types of all geometries, or an empty array if they are not known. |
-| crs            | object\|null | **OPTIONAL** [PROJJSON](https://proj.org/specifications/projjson.html) object representing the Coordinate Reference System (CRS) of the geometry. If the crs field is not included then the data in this column must be stored in longitude, latitude based on the WGS84 datum, and CRS-aware implementations should assume a default value of [OGC:CRS84](https://www.opengis.net/def/crs/OGC/1.3/CRS84). A value of `null` indicates that the CRS is undefined or unknown. |
-| orientation    | string       | **OPTIONAL** Winding order of exterior ring of polygons. If present must be `"counterclockwise"`; interior rings are wound in opposite order. If absent, no assertions are made regarding the winding order. |
-| edges          | string       | **OPTIONAL** Name of the coordinate system for the edges. Must be one of `"planar"` or `"spherical"`. The default value is `"planar"`. |
-| bbox           | \[number]    | **OPTIONAL** Bounding Box of the geometries in the file, formatted according to [RFC 7946, section 5](https://tools.ietf.org/html/rfc7946#section-5). |
-| epoch          | number       | **OPTIONAL** Coordinate epoch in case of a dynamic CRS, expressed as a decimal year. |
+| encoding       | string       | **REQUIRED.** Name of the geometry encoding format. Currently only `"WKB"` is supported. |
+| geometry_types | \[string]    | **REQUIRED.** The geometry types of all geometries, or an empty array if they are not known. |
+| crs            | object\|null | [PROJJSON](https://proj.org/specifications/projjson.html) object representing the Coordinate Reference System (CRS) of the geometry. If the crs field is not included then the data in this column must be stored in longitude, latitude based on the WGS84 datum, and CRS-aware implementations should assume a default value of [OGC:CRS84](https://www.opengis.net/def/crs/OGC/1.3/CRS84). A value of `null` indicates that the CRS is undefined or unknown. |
+| orientation    | string       | Winding order of exterior ring of polygons. If present must be `"counterclockwise"`; interior rings are wound in opposite order. If absent, no assertions are made regarding the winding order. |
+| edges          | string       | Name of the coordinate system for the edges. Must be one of `"planar"` or `"spherical"`. The default value is `"planar"`. |
+| bbox           | \[number]    | Bounding Box of the geometries in the file, formatted according to [RFC 7946, section 5](https://tools.ietf.org/html/rfc7946#section-5). |
+| epoch          | number       | Coordinate epoch in case of a dynamic CRS, expressed as a decimal year. |
 
 #### crs
 
@@ -101,7 +105,7 @@ with the epoch at which they are valid.
 
 The optional `epoch` field allows to specify this in case the `crs` field
 defines a a dynamic CRS. The coordinate epoch is expressed as a decimal year
-(e.g. 2021.47). Currently, this specification only supports an epoch per
+(e.g. `2021.47`). Currently, this specification only supports an epoch per
 column (and not per geometry).
 
 #### encoding
@@ -142,9 +146,9 @@ specify `["Point"]`, but it is expected to list `["Point Z"]`.
 
 This attribute indicates the winding order of polygons. The only available value is `"counterclockwise"`. All vertices of exterior polygon rings MUST be ordered in the counterclockwise direction and all interior rings MUST be ordered in the clockwise direction.
 
-If no value is set, no assertions are made about winding order or consistency of such between exterior and interior rings or between individual geometries within a dataset.  Readers are responsible for verifying and if necessary re-ordering vertices as required for their analytical representation.
+If no value is set, no assertions are made about winding order or consistency of such between exterior and interior rings or between individual geometries within a dataset. Readers are responsible for verifying and if necessary re-ordering vertices as required for their analytical representation.
 
-Writers are encouraged but not required to set orientation="counterclockwise" for portability of the data within the broader ecosystem.
+Writers are encouraged but not required to set `orientation="counterclockwise"` for portability of the data within the broader ecosystem.
 
 It is recommended to always set the orientation (to counterclockwise) if `edges` is `"spherical"` (see below).
 
@@ -166,14 +170,14 @@ Implementations of this schema may choose to use those bounding boxes to filter
 partitions (files) of a partitioned dataset.
 
 The bbox, if specified, must be encoded with an array representing the range of values for each dimension in the
-geometry coordinates.  For geometries in a geographic coordinate reference system, longitude and latitude values are
-listed for the most southwesterly coordinate followed by values for the most northeasterly coordinate.  This follows the
+geometry coordinates. For geometries in a geographic coordinate reference system, longitude and latitude values are
+listed for the most southwesterly coordinate followed by values for the most northeasterly coordinate. This follows the
 GeoJSON specification ([RFC 7946, section 5](https://tools.ietf.org/html/rfc7946#section-5)), which also describes how
 to represent the bbox for a set of geometries that cross the antimeridian.
 
 For non-geographic coordinate reference systems, the items in the bbox are minimum values for each dimension followed by
-maximum values for each dimension.  For example, given geometries that have coordinates with two dimensions, the bbox
-would have the form `[<xmin>, <ymin>, <xmax>, <ymax>]`.  For three dimensions, the bbox would have the form
+maximum values for each dimension. For example, given geometries that have coordinates with two dimensions, the bbox
+would have the form `[<xmin>, <ymin>, <xmax>, <ymax>]`. For three dimensions, the bbox would have the form
 `[<xmin>, <ymin>, <zmin>, <xmax>, <ymax>, <zmax>]`.
 
 The bbox values are in the same coordinate reference system as the geometry.
@@ -182,22 +186,15 @@ The bbox values are in the same coordinate reference system as the geometry.
 
 #### Feature identifiers
 
-If you are using GeoParquet to serialize geospatial data with feature identifiers, it is recommended that you create your own [file key/value metadata](https://github.com/apache/parquet-format#metadata) to indicate the column that represents this identifier.  As an example, GDAL writes additional metadata using the `gdal:schema` key including information about feature identifiers and other information outside the scope of the GeoParquet specification.
-
-#### Example data
-
-You can find an example in the [examples](../examples/) folder.
-
-[parquet]: https://parquet.apache.org/
-
+If you are using GeoParquet to serialize geospatial data with feature identifiers, it is recommended that you create your own [file key/value metadata](https://github.com/apache/parquet-format#metadata) to indicate the column that represents this identifier. As an example, GDAL writes additional metadata using the `gdal:schema` key including information about feature identifiers and other information outside the scope of the GeoParquet specification.
 
 ### OGC:CRS84 details
 
-The PROJJSON JSON object for OGC:CRS84 is:
+The PROJJSON object for OGC:CRS84 is:
 
 ```json
 {
-    "$schema": "https://proj.org/schemas/v0.4/projjson.schema.json",
+    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
     "type": "GeographicCRS",
     "name": "WGS 84 longitude-latitude",
     "datum": {

--- a/format-specs/geoparquet.md
+++ b/format-specs/geoparquet.md
@@ -37,7 +37,7 @@ These are both stored under a `geo` key in the parquet metadata (the [`FileMetaD
 
 ## File metadata
 
-All file-level metadata should be included under the "geo" key in the parquet metadata.
+All file-level metadata should be included under the `geo` key in the parquet metadata.
 
 |     Field Name     |  Type  |                             Description                              |
 | ------------------ | ------ | -------------------------------------------------------------------- |

--- a/scripts/write_nz_building_outline.py
+++ b/scripts/write_nz_building_outline.py
@@ -13,7 +13,7 @@ import pyarrow.parquet as pq
 import pygeos
 from numpy.typing import NDArray
 
-GEOPARQUET_VERSION = "0.4.0"
+GEOPARQUET_VERSION = "0.5.0-dev"
 AVAILABLE_COMPRESSIONS = ["NONE", "SNAPPY", "GZIP", "BROTLI", "LZ4", "ZSTD"]
 
 PygeosGeometryArray = NDArray[pygeos.Geometry]


### PR DESCRIPTION
Some proposals for a cleaner README:
- Directly link to examples and JSON Schema directly so that they are easy to find (the schema wasn't linked to at all from the spec, the spec itself wasn't linked to at all from the repo README)
- Update version numbers to one consistent value instead of 0.4.0 and 0.5.0-dev in different places
- Markdown tweaks, e.g. code fences
- Remove "Optional" as it is in STAC to make it easier to see the difference directly. Only required fields are declared, all other are implicitly optional.
- Don't hide links somewhere in the text