### PR TITLE
Require at least one column

### DIFF
--- a/format-specs/schema.json
+++ b/format-specs/schema.json
@@ -15,6 +15,7 @@
     },
     "columns": {
       "type": "object",
+      "minProperties": 1,
       "patternProperties": {
         ".+": {
           "type": "object",


### PR DESCRIPTION
As discussed in https://github.com/opengeospatial/geoparquet/pull/141#discussion_r1042110576, the columns should likely have at least one entry. This requires it in the schema.