### PR TITLE
Link to the release procedure

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+# Release Procedure
+
+Please read through the [Release Procedure](https://github.com/opengeospatial/geoparquet/wiki/Release-Process) steps on the wiki.
+
+After going through a few releases and ideally streamlining the process, you'll likely find those steps documented in this file instead of the wiki.


### PR DESCRIPTION
This adds a `RELEASE.md` doc that links to the [release procedure](https://github.com/opengeospatial/geoparquet/wiki/Release-Process) on the wiki.  The justification for keeping that page on the wiki right now is that it is easier to iterate on improvements there.  But I agree it needs to be easier to find.