### PR TITLE
Require two elements in covering elements

### DIFF
--- a/format-specs/schema.json
+++ b/format-specs/schema.json
@@ -86,7 +86,8 @@
                         { "type": "string" },
                         { "const": "xmin" }
                       ],
-                      "additionalItems": false
+                      "minItems": 2,
+                      "maxItems": 2
                     },
                     "xmax": {
                       "type": "array",
@@ -94,7 +95,8 @@
                         { "type": "string" },
                         { "const": "xmax" }
                       ],
-                      "additionalItems": false
+                      "minItems": 2,
+                      "maxItems": 2
                     },
                     "ymin": {
                       "type": "array",
@@ -102,7 +104,8 @@
                         { "type": "string" },
                         { "const": "ymin" }
                       ],
-                      "additionalItems": false
+                      "minItems": 2,
+                      "maxItems": 2
                     },
                     "ymax": {
                       "type": "array",
@@ -110,7 +113,8 @@
                         { "type": "string" },
                         { "const": "ymax" }
                       ],
-                      "additionalItems": false
+                      "minItems": 2,
+                      "maxItems": 2
                     }
                   }
                 }

--- a/scripts/test_json_schema.py
+++ b/scripts/test_json_schema.py
@@ -236,6 +236,26 @@ metadata["columns"]["geometry"]["covering"]["bbox"] = {
 valid_cases["valid_but_not_bbox_struct_name"] = metadata
 
 metadata = copy.deepcopy(metadata_covering_template)
+metadata["columns"]["geometry"]["covering"]["bbox"]["xmin"] = []
+invalid_cases["xmin_array_length_must_be_2_is_0"] = metadata
+
+metadata = copy.deepcopy(metadata_covering_template)
+metadata["columns"]["geometry"]["covering"]["bbox"]["ymax"] = []
+invalid_cases["ymax_array_length_must_be_2_is_0"] = metadata
+
+metadata = copy.deepcopy(metadata_covering_template)
+metadata["columns"]["geometry"]["covering"]["bbox"]["ymin"] = ["column"]
+invalid_cases["ymin_array_length_must_be_2_is_1"] = metadata
+
+metadata = copy.deepcopy(metadata_covering_template)
+metadata["columns"]["geometry"]["covering"]["bbox"]["xmax"] = ["column"]
+invalid_cases["xmax_array_length_must_be_2_is_1"] = metadata
+
+metadata = copy.deepcopy(metadata_covering_template)
+metadata["columns"]["geometry"]["covering"]["bbox"]["xmin"] = ["xmin", "xmin", "xmin"]
+invalid_cases["xmin_array_length_must_be_2_is_3"] = metadata
+
+metadata = copy.deepcopy(metadata_covering_template)
 metadata["columns"]["geometry"]["covering"].pop("bbox")
 invalid_cases["empty_geometry_bbox"] = metadata
 


### PR DESCRIPTION
The covering schemas for xmin, xmax etc. allow 0-2 elements in the array, but I think according to the spec it should always be exactly two elements.