### PR TITLE
Added file extension recommendation

### DIFF
--- a/format-specs/geoparquet.md
+++ b/format-specs/geoparquet.md
@@ -289,3 +289,7 @@ The CRS is likely equivalent to OGC:CRS84 for a GeoParquet file if the `id` elem
 It is reasonable for implementations to require that one of the above `id` elements are present and skip further tests to determine if the CRS is functionally equivalent with OGC:CRS84.
 
 Note: EPSG:4326 and OGC:CRS84 are equivalent with respect to this specification because this specification specifically overrides the coordinate axis order in the `crs` to be longitude-latitude.
+
+## File Extension
+
+It is RECOMMENDED to always use `.parquet` as the file suffix for a GeoParquet file.


### PR DESCRIPTION
Adds a recommendation to use `.parquet` for the file extension, as discussed in #211

From what I could tell the core parquet specification does not require a specific file extension, so it didn't seem good to require it.

I did not include 'justification' in the text, like a line about how it's not required by the core specification but that some readers may expect it. I figure we can just refer to the discussion of the issue if people want to understand.

I also stopped short of including the `.geo.parquet` [recommendation](https://github.com/opengeospatial/geoparquet/issues/211#issuecomment-2090650490) from @hobu. I started to write it, but then didn't find any specific recommendation in https://copc.io/, so it seemed maybe a little overspecified? Happy to add it, but was also thinking we could just mention it in a blog post and put up some examples of it. Could also have validators issue a 'warning' and recommend it when people use .geoparquet.

It does feel like the spec could use a bit of reorganization, and it's probably time for a table of contents at the top. I just put this at the very bottom, which does feel quite buried, but the other option was to stick it at the very top. I figured I'd get this in (and maybe #115) and then try a PR that just re-organizes. 

Closes #211 