### PR TITLE
clarified that the bbox must be in the same crs as the geometry

### DIFF
--- a/format-specs/geoparquet.md
+++ b/format-specs/geoparquet.md
@@ -197,7 +197,7 @@ The bbox, if specified, MUST be encoded with an array representing the range of 
 
 For non-geographic coordinate reference systems, the items in the bbox are minimum values for each dimension followed by maximum values for each dimension. For example, given geometries that have coordinates with two dimensions, the bbox would have the form `[<xmin>, <ymin>, <xmax>, <ymax>]`. For three dimensions, the bbox would have the form `[<xmin>, <ymin>, <zmin>, <xmax>, <ymax>, <zmax>]`.
 
-The bbox values are in the same coordinate reference system as the geometry.
+The bbox values MUST be in the same coordinate reference system as the geometry.
 
 #### covering
 


### PR DESCRIPTION
Very small change here as we already stated that the coordinates 'are' in the same projection, but changed to 'MUST' for clarity.

Closes #203, and there's additional discussion there.