### PR TITLE
Updated projjson schema link to 0.7 (and new link)

### DIFF
--- a/format-specs/schema.json
+++ b/format-specs/schema.json
@@ -36,7 +36,7 @@
             "crs": {
               "oneOf": [
                 {
-                  "$ref": "https://proj.org/en/latest/schemas/v0.7/projjson.schema.json"
+                  "$ref": "https://proj.org/schemas/v0.7/projjson.schema.json"
                 },
                 {
                   "type": "null"

--- a/format-specs/schema.json
+++ b/format-specs/schema.json
@@ -36,7 +36,7 @@
             "crs": {
               "oneOf": [
                 {
-                  "$ref": "https://proj.org/schemas/v0.5/projjson.schema.json"
+                  "$ref": "https://proj.org/en/latest/schemas/v0.7/projjson.schema.json"
                 },
                 {
                   "type": "null"


### PR DESCRIPTION
Opening this PR more to continue the discussion in #180, since if we do want to be updating the schema versions than 1.1 release seems like a good time to.

I'm not sure what is the proper url to put in, I used https://proj.org/en/latest/schemas/v0.7/projjson.schema.json as the 'main' one seems to redirect there: https://proj.org/schemas/v0.7/projjson.schema.json But the 'id' is the latter one. There's additional discussion of this in https://github.com/OSGeo/PROJ/issues/4088

The case for updating the schema is that 0.5 -> 0.7 is mostly (all?) additive, so everything in the past should work.

The case against is that we should do something different than hard code in a version number. Or if we have to since that's how schemas work then we should target a new one.
