### PR TITLE
Remove requirement that geometry columns must not be a group field

### DIFF
--- a/format-specs/geoparquet.md
+++ b/format-specs/geoparquet.md
@@ -18,7 +18,7 @@ See the [encoding](#encoding) section below for more details.
 
 ### Nesting
 
-Geometry columns MUST be at the root of the schema. A geometry MUST NOT be a group field or nested in a group. In practice, this means that when writing to GeoParquet from another format, geometries cannot be contained in complex or nested types such as structs, lists, arrays, or map types.
+Geometry columns MUST be at the root of the schema. In practice, this means that when writing to GeoParquet from another format, geometries cannot be contained in complex or nested types such as structs, lists, arrays, or map types.
 
 ### Repetition
 


### PR DESCRIPTION
The new native geometry encodings from #189 are incompatible with the requirement that geometry columns must not be group fields.  This branch suggests removing that requirement.

Fixes #233.