### PR TITLE
Fix typo in multipolygon example

### DIFF
--- a/format-specs/geoparquet.md
+++ b/format-specs/geoparquet.md
@@ -132,7 +132,7 @@ optional group geometry (List) {
       repeated group list {
         required group element (List) {
           // the list of coordinates of one ring
-          required group list {
+          repeated group list {
             required group element {
               required double x;
               required double y;


### PR DESCRIPTION
It looks like this line should be `repeated group list` instead of `required group list` in the geoarrow multipolygon example.