### PR TITLE
Updates to OGC requirements

### DIFF
--- a/format-specs/requirements/requirement-cm.adoc
+++ b/format-specs/requirements/requirement-cm.adoc
@@ -1,0 +1,6 @@
+[requirement]
+====
+[%metadata]
+identifier:: /req/core/columnmetadata
+part:: Each geometry column in the dataset SHALL have an entry in the "columns" object, and the key of the object MUST have the same name as the geometry column in the dataset.
+====

--- a/format-specs/requirements/requirement-fm.adoc
+++ b/format-specs/requirements/requirement-fm.adoc
@@ -1,0 +1,7 @@
+[requirement]
+====
+[%metadata]
+identifier:: /req/core/filemetadata
+part:: A GeoParquet file SHALL contain an appropriate value in the "version" key in the file metadata to indicate its version.
+part:: The "primary_column" key SHALL be present in the file metadata, and its value MUST be a string that matches one of the column metadata keys.
+====

--- a/format-specs/requirements/requirement001.adoc
+++ b/format-specs/requirements/requirement001.adoc
@@ -2,6 +2,8 @@
 ====
 [%metadata]
 identifier:: /req/core/geometry-columns
+part:: Each column metadata object MUST include a valid "encoding" string. 
+part:: For this version of the GeoParquet specification the value of the encoding string MUST be "WKB".
 part:: Geometry columns SHALL be stored using the BYTE_ARRAY parquet type.
 part:: Geometries SHALL be encoded as https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary[Well Known Binary (WKB)].
 ====

--- a/format-specs/requirements/requirement001.adoc
+++ b/format-specs/requirements/requirement001.adoc
@@ -4,6 +4,6 @@
 identifier:: /req/core/geometry-columns
 part:: Each column metadata object MUST include a valid "encoding" string. 
 part:: For this version of the GeoParquet specification the value of the encoding string MUST be "WKB".
-part:: Geometry columns SHALL be stored using the BYTE_ARRAY parquet type.
-part:: Geometries SHALL be encoded as https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary[Well Known Binary (WKB)].
+part:: Geometry columns with "WKB" as the encoding SHALL be stored using the BYTE_ARRAY parquet type.
+part:: Geometries in geometry columns with "WKB" as the encoding SHALL be encoded as https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary[Well Known Binary (WKB)].
 ====

--- a/format-specs/requirements/requirements009.adoc
+++ b/format-specs/requirements/requirements009.adoc
@@ -1,0 +1,8 @@
+[requirement]
+====
+[%metadata]
+identifier:: /req/core/geoemtrytypes
+part:: Every geometry column metadata object must include a "geometry_types" list.
+part:: All geometry types that are present in the file MUST be included in the "geometry_types" metadata, if the geometry_types list is not empty.
+part:: If the geometry types are not known then the geometry_types list MUST be empty.
+====


### PR DESCRIPTION
Started making some updates to the OGC version of the spec (still a PR at #224), based on mismatches with [GPQ](https://github.com/planetlabs/gpq). See https://github.com/opengeospatial/geoparquet/wiki/GPQ-validation-vs-draft-OGC-requirements for raw notes on changes needed.