### PR TITLE
Add explicit language around edges and ensure available options capture engine behaviours that import/export Parquet

### DIFF
--- a/format-specs/geoparquet.md
+++ b/format-specs/geoparquet.md
@@ -216,7 +216,7 @@ do not contain edges (i.e., the column only contains points or empty geometries)
 For columns that contain edges, the error introduced by ignoring the original
 edge interpretation is similar to the error introduced by applying a coordinate
 transformation to vertices (which is usually small but may be large or create
-invalid geometries, particularly if vertices are not closely spaced). Ignroing
+invalid geometries, particularly if vertices are not closely spaced). Ignoring
 the original edge interpretation will silently introduce invalid and/or
 misinterpreted geometries for any edge that crosses the antimeridian (i.e.,
 longitude 180/-180) when translating from `"spherical"` or `"geodesic"` edges

--- a/format-specs/geoparquet.md
+++ b/format-specs/geoparquet.md
@@ -210,7 +210,7 @@ If no value is set, the default value to assume is `"planar"`.
 Note if `edges` is `"spherical"` then it is RECOMMENDED that `orientation` is always ensured to be `"counterclockwise"`. If it is not set, it is not clear how polygons should be interpreted within spherical coordinate systems, which can lead to major analytical errors if interpreted incorrectly. In this case, software will typically interpret the rings of a polygon such that it encloses at most half of the sphere (i.e. the smallest polygon of both ways it could be interpreted). But the specification itself does not make any guarantee about this.
 
 If an implementation only has support for a single edge interpretation (e.g.,
-a library with only planar edge support), an column with a different edge type
+a library with only planar edge support), a column with a different edge type
 may be imported without loosing information if the geometries in the column
 do not contain edges (i.e., the column only contains points or empty geometries).
 For columns that contain edges, the error introduced by ignoring the original


### PR DESCRIPTION
This PR is an attempt to improve the language around the "edges" key, to ensure it can capture the intent of all potential producers. We've done more research since the original wording and have some specific examples and use cases where implementations and specifications have struggled. Notably, this PR:

 - Adds a "geodesic" option. I only knew about the spherical approximation because I'd only worked with s2, but it's been rightly pointed out that geodesic edges that consider the ellipsoid are a thing in several major engines.
- Adds examples of producers and consumers that use each edge type
- Adds explicit language around "planar" from simple features access
- Adds practical considerations around importing  a column with an unsupported edge type (basically: you can import them silently if there are no edges; you should force an opt-in or display a prominent warning otherwise).

I've also added a PR to add similar language to GeoArrow https://github.com/geoarrow/geoarrow/pull/79 .