### PR TITLE
GeoParquet 2.0: allow <authority>:<code> CRS in addition to inline PROJJSON

### DIFF
--- a/format-specs/geoparquet.md
+++ b/format-specs/geoparquet.md
@@ -49,7 +49,7 @@ Each geometry column in the dataset MUST be included in the `columns` field abov
 | -------------- | ------------ | ----------- |
 | encoding       | string       | **REQUIRED.** Name of the geometry encoding format. Only `"WKB"` is supported. |
 | geometry_types | \[string]    | **REQUIRED.** The geometry types of all geometries, or an empty array if they are not known. |
-| crs            | object\|null | [PROJJSON](https://proj.org/specifications/projjson.html) object representing the Coordinate Reference System (CRS) of the geometry. If the field is not provided, the default CRS is [OGC:CRS84](https://www.opengis.net/def/crs/OGC/1.3/CRS84), which means the data in this column must be stored in longitude, latitude based on the WGS84 datum. |
+| crs            | object\|string\|null | [PROJJSON](https://proj.org/specifications/projjson.html) object, or an `<authority>:<code>` string (e.g. `"EPSG:4326"`), representing the Coordinate Reference System (CRS) of the geometry. The value MUST equal the Parquet logical-type `crs` property in the same form. If the field is not provided, the default CRS is [OGC:CRS84](https://www.opengis.net/def/crs/OGC/1.3/CRS84), which means the data in this column must be stored in longitude, latitude based on the WGS84 datum. |
 | orientation    | string       | Winding order of exterior ring of polygons. If present must be `"counterclockwise"`; interior rings are wound in opposite order. If absent, no assertions are made regarding the winding order. |
 | edges          | string       | Describes how to interpret the edges of the geometries. Must be one of `planar`, `spherical`, `vincenty`, `thomas`, `andoyer`, `karney`. The default value is `planar`.
 | bbox           | \[number]    | Bounding Box of the geometries in the file, formatted according to [RFC 7946, section 5](https://tools.ietf.org/html/rfc7946#section-5). |
@@ -59,27 +59,49 @@ Each geometry column in the dataset MUST be included in the `columns` field abov
 
 The Coordinate Reference System (CRS) is an optional parameter for each geometry column defined in GeoParquet format.
 
-The CRS MUST be provided in [PROJJSON](https://proj.org/specifications/projjson.html) format, which is a JSON encoding of [WKT2:2019 / ISO-19162:2019](https://docs.opengeospatial.org/is/18-010r7/18-010r7.html), which itself implements the model of [OGC Topic 2: Referencing by coordinates abstract specification / ISO-19111:2019](http://docs.opengeospatial.org/as/18-005r4/18-005r4.html). Apart from the difference of encodings, the semantics are intended to match WKT2:2019, and a CRS in one encoding can generally be represented in the other.
+In GeoParquet 2.0 the CRS is carried both on the Parquet `GEOMETRY`/`GEOGRAPHY` logical type's `crs` property and (mirrored) on the GeoParquet column-metadata `crs` field. The two MUST be equal and MUST be in the same form.
+
+The CRS MAY be expressed in one of two forms:
+
+1. **Inline [PROJJSON](https://proj.org/specifications/projjson.html)** — a complete CRS definition, which is a JSON encoding of [WKT2:2019 / ISO-19162:2019](https://docs.opengeospatial.org/is/18-010r7/18-010r7.html), itself implementing the model of [OGC Topic 2: Referencing by coordinates abstract specification / ISO-19111:2019](http://docs.opengeospatial.org/as/18-005r4/18-005r4.html). This is the canonical form.
+2. **An `<authority>:<code>` string** — e.g. `"OGC:CRS84"`, `"EPSG:4326"`, `"EPSG:3857"`, `"IGNF:ATI"`. The authority and code MUST be one published by a recognized CRS authority (well-known authorities include OGC, EPSG, ESRI, and IGNF; see <https://spatialreference.org/> for an index).
 
 If the `crs` key does not exist, all coordinates in the geometries MUST use longitude, latitude based on the WGS84 datum, and the default value is [OGC:CRS84](https://www.opengis.net/def/crs/OGC/1.3/CRS84) for CRS-aware implementations. Note that a missing `crs` key has different meaning than a `crs` key set to `null` (see below).
 
-[OGC:CRS84](https://www.opengis.net/def/crs/OGC/1.3/CRS84) is equivalent to the well-known [EPSG:4326](https://epsg.org/crs_4326/WGS-84.html) but changes the axis from latitude-longitude to longitude-latitude.
+[OGC:CRS84](https://www.opengis.net/def/crs/OGC/1.3/CRS84) is equivalent to the well-known [EPSG:4326](https://epsg.org/crs_4326/WGS-84.html) but changes the axis from latitude-longitude to longitude-latitude. See below for additional details about representing or identifying OGC:CRS84, including when it arrives as an `<authority>:<code>` string rather than as PROJJSON.
 
-See below for additional details about representing or identifying OGC:CRS84.
-
-The value of this key may be explicitly set to `null` to indicate that there is no CRS assigned to this column (CRS is undefined or unknown).
-
-The `crs` field of GeoParquet MUST reflect the crs of the Parquet `crs` property on the GEOMETRY or GEOGRAPHY logical type.
+The value of this key may be explicitly set to `null` to indicate that there is no CRS assigned to this column (CRS is undefined or unknown). Because the Parquet core specification has no native way to express "no CRS" (an absent Parquet `crs` defaults to OGC:CRS84), a writer that sets the GeoParquet column-metadata `crs` to `null` MUST omit the Parquet logical-type `crs` property; the GeoParquet `null` is authoritative and overrides Parquet's default-to-OGC:CRS84 interpretation in this case.
 
 ##### `crs` Parquet property
 
-The Parquet Geospatial definitions have a [crs customization](https://github.com/apache/parquet-format/blob/apache-parquet-format-2.12.0/Geospatial.md#crs-customization) section
-that gives flexibility for how to specify the crs.
+The Parquet Geospatial definitions have a [crs customization](https://github.com/apache/parquet-format/blob/apache-parquet-format-2.12.0/Geospatial.md#crs-customization) section that permits four forms: inline PROJJSON, `<authority>:<code>`, `srid:<identifier>`, and `projjson:<key_name>`.
 
-The GeoParquet 2.0 specification gives less flexibility. To comply with
-GeoParquet 2.0 if there is a non-default crs then the crs field in the Parquet geometry or geography type MUST be an in-line projjson representation of the crs. This is allowed by the Parquet specification, though it is not explicitly articulated.
+GeoParquet 2.0 is more restrictive:
 
-Readers of geospatial Parquet data SHOULD try to parse other crs representations in the Parquet metadata.
+- A GeoParquet 2.0 writer MUST use one of:
+  - inline PROJJSON, or
+  - an `<authority>:<code>` string.
+- A GeoParquet 2.0 writer MUST NOT use `srid:<identifier>` (no authority context; ambiguous across systems) or `projjson:<key_name>` (indirect reference via another metadata key; no ergonomic benefit over inline PROJJSON).
+- A GeoParquet 2.0 writer SHOULD prefer inline PROJJSON. It is self-describing, requires no external CRS registry, and matches the GeoParquet 1.x convention.
+- A GeoParquet 2.0 writer MAY use `<authority>:<code>` when:
+  - the CRS is precisely identified by a well-known authority entry, AND
+  - the writing environment lacks a PROJJSON generator (e.g., pure-SQL pipelines, lightweight browser-side writers), OR
+  - reducing per-file metadata size is desirable (e.g., very many very small files).
+
+A GeoParquet 2.0 reader MUST handle both writer-permitted forms (inline PROJJSON and `<authority>:<code>`).
+
+Readers of geospatial Parquet data SHOULD additionally try to parse the other Parquet-core `crs` representations (`srid:<identifier>` and `projjson:<key_name>`) when encountered. Such files are not conformant GeoParquet 2.0, but supporting them improves interoperability with the broader Parquet geospatial ecosystem.
+
+The GeoParquet column-metadata `crs` field and the Parquet logical-type `crs` property MUST mirror each other exactly:
+
+| Parquet logical-type `crs`              | GeoParquet column-metadata `crs`           | Meaning                                       |
+| --------------------------------------- | ------------------------------------------ | --------------------------------------------- |
+| absent (Parquet default)                | absent                                     | OGC:CRS84                                     |
+| inline PROJJSON object                  | the same inline PROJJSON object            | CRS fully described in metadata               |
+| `<authority>:<code>` string             | the same `<authority>:<code>` string       | CRS identified by authority code              |
+| absent (writer signaling "no CRS")      | `null`                                     | CRS explicitly undefined / unknown            |
+
+The two fields MUST NOT disagree in form (one being PROJJSON while the other is `<authority>:<code>`) or in value.
 
 #### epoch
 
@@ -231,6 +253,8 @@ The CRS is likely equivalent to OGC:CRS84 for a GeoParquet file if the `id` elem
 It is reasonable for implementations to require that one of the above `id` elements are present and skip further tests to determine if the CRS is functionally equivalent with OGC:CRS84.
 
 Note: EPSG:4326 and OGC:CRS84 are equivalent with respect to this specification because this specification specifically overrides the coordinate axis order in the `crs` to be longitude-latitude.
+
+When the CRS arrives in the `<authority>:<code>` form, the values `"OGC:CRS84"` and `"EPSG:4326"` are likewise equivalent to OGC:CRS84 for the purposes of this specification.
 
 ## Version Compatibility
 

--- a/format-specs/schema.json
+++ b/format-specs/schema.json
@@ -39,6 +39,11 @@
                   "$ref": "https://proj.org/schemas/v0.7/projjson.schema.json"
                 },
                 {
+                  "type": "string",
+                  "description": "An <authority>:<code> CRS reference (e.g. 'OGC:CRS84', 'EPSG:4326', 'EPSG:3857', 'IGNF:ATI').",
+                  "pattern": "^[A-Za-z][A-Za-z0-9_-]*:[A-Za-z0-9_.-]+$"
+                },
+                {
                   "type": "null"
                 }
               ]

--- a/scripts/test_json_schema.py
+++ b/scripts/test_json_schema.py
@@ -156,15 +156,59 @@ metadata["columns"]["geometry"]["geometry_types"] = ["PointZ"]
 invalid_cases["geometry_type_z_missing_space"] = metadata
 
 
-# CRS - explicit null
+# CRS - explicit null (kept in 2.0 pending separate `null`-deprecation discussion)
 
 metadata = copy.deepcopy(metadata_template)
 metadata["columns"]["geometry"]["crs"] = None
 valid_cases["crs_null"] = metadata
 
+# CRS - <authority>:<code> string (new in 2.0)
+
 metadata = copy.deepcopy(metadata_template)
 metadata["columns"]["geometry"]["crs"] = "EPSG:4326"
-invalid_cases["crs_string"] = metadata
+valid_cases["crs_authority_code_epsg_4326"] = metadata
+
+metadata = copy.deepcopy(metadata_template)
+metadata["columns"]["geometry"]["crs"] = "OGC:CRS84"
+valid_cases["crs_authority_code_ogc_crs84"] = metadata
+
+metadata = copy.deepcopy(metadata_template)
+metadata["columns"]["geometry"]["crs"] = "EPSG:3857"
+valid_cases["crs_authority_code_epsg_3857"] = metadata
+
+metadata = copy.deepcopy(metadata_template)
+metadata["columns"]["geometry"]["crs"] = "IGNF:ATI"
+valid_cases["crs_authority_code_ignf_ati"] = metadata
+
+# CRS - malformed strings MUST NOT validate
+
+metadata = copy.deepcopy(metadata_template)
+metadata["columns"]["geometry"]["crs"] = ""
+invalid_cases["crs_string_empty"] = metadata
+
+metadata = copy.deepcopy(metadata_template)
+metadata["columns"]["geometry"]["crs"] = "EPSG"
+invalid_cases["crs_string_no_colon"] = metadata
+
+metadata = copy.deepcopy(metadata_template)
+metadata["columns"]["geometry"]["crs"] = ":4326"
+invalid_cases["crs_string_leading_colon"] = metadata
+
+metadata = copy.deepcopy(metadata_template)
+metadata["columns"]["geometry"]["crs"] = "EPSG:"
+invalid_cases["crs_string_trailing_colon"] = metadata
+
+metadata = copy.deepcopy(metadata_template)
+metadata["columns"]["geometry"]["crs"] = "EPSG/4326"
+invalid_cases["crs_string_wrong_separator"] = metadata
+
+metadata = copy.deepcopy(metadata_template)
+metadata["columns"]["geometry"]["crs"] = "123:4326"  # authority must start with a letter
+invalid_cases["crs_string_numeric_authority"] = metadata
+
+metadata = copy.deepcopy(metadata_template)
+metadata["columns"]["geometry"]["crs"] = "urn:ogc:def:crs:EPSG::4326"  # extra colons not allowed
+invalid_cases["crs_string_urn_form"] = metadata
 
 
 # Bbox


### PR DESCRIPTION
Permits writers to emit the Parquet `crs` property as either inline PROJJSON (the canonical, preferred form) or an `<authority>:<code>` string (e.g. `EPSG:4326`, `OGC:CRS84`). The other Parquet-core forms (`srid:<id>`, `projjson:<key>`) remain disallowed for writers, but readers SHOULD continue to tolerate them for interoperability with the broader Parquet geospatial ecosystem.

The GeoParquet column-metadata `crs` field is widened to accept the same `<authority>:<code>` form, and the two CRS fields (Parquet logical-type `crs` and GeoParquet column-metadata `crs`) MUST mirror each other exactly in both form and value.

### Why

The current 2.0 draft requires inline PROJJSON for any non-default CRS, which forces every writer to ship a PROJJSON generator (pyproj or equivalent) even to emit `EPSG:4326`. That's a real burden for pure-SQL pipelines, lightweight browser-side writers, and high-file-count workloads. Apache Parquet's own geospatial spec lists `<authority>:<code>` as a first-class option alongside PROJJSON; constraining writers to those two forms (and rejecting the more ambiguous `srid:<id>` and indirect `projjson:<key>` forms) gives us alignment with Parquet core without exposing readers to four parsing paths.

PROJJSON remains the **preferred** writer form per spec language; `<authority>:<code>` is a permitted shortcut.

### Summary of changes

- `format-specs/schema.json`: `crs` field now accepts `object` (PROJJSON), `string` (matching `^[A-Za-z][A-Za-z0-9_-]*:[A-Za-z0-9_.-]+$`), or `null`.
- `format-specs/geoparquet.md`:
  - Column-metadata `crs` row updated (`object|string|null`).
  - §`crs` subsection rewritten to enumerate the two permitted forms and the writer preference.
  - §`crs` Parquet property subsection rewritten with explicit writer MUST / MUST NOT / SHOULD / MAY rules, the reader MUST + SHOULD-tolerate rules, and a mirroring table for the GeoParquet/Parquet `crs` correspondence.
  - §OGC:CRS84 details: added a sentence noting that authority-code `OGC:CRS84` and `EPSG:4326` are likewise equivalent to OGC:CRS84.
- `scripts/test_json_schema.py`: new positive cases (`crs_authority_code_*`) for the four common authority codes; new negative cases (`crs_string_*`) for malformed strings; the previous `crs_string` invalid case (for `"EPSG:4326"`) is now valid.

### Mirroring table (from the new spec text)

| Parquet logical-type `crs`            | GeoParquet column-metadata `crs`        | Meaning                                  |
| ------------------------------------- | --------------------------------------- | ---------------------------------------- |
| absent (Parquet default)              | absent                                  | OGC:CRS84                                |
| inline PROJJSON object                | the same inline PROJJSON object         | CRS fully described in metadata          |
| `<authority>:<code>` string           | the same `<authority>:<code>` string    | CRS identified by authority code         |
| absent (writer signaling "no CRS")    | `null`                                  | CRS explicitly undefined / unknown       |

### Open / followup

The treatment of `null` (explicit "no CRS / unknown") in 2.0 is preserved here for 1.x compatibility but is awkward: Parquet core has no native way to express "no CRS." A followup discussion may propose removing `null` from 2.0; not in scope for this PR.

### Test results

```
57 passed in 0.5s  (test_json_schema.py)
72 passed in 12.2s (full scripts/ test suite)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)