### PR TITLE
GeoParquet 2.0: discuss removing null from the crs field

### DIFF
--- a/format-specs/geoparquet.md
+++ b/format-specs/geoparquet.md
@@ -49,7 +49,7 @@ Each geometry column in the dataset MUST be included in the `columns` field abov
 | -------------- | ------------ | ----------- |
 | encoding       | string       | **REQUIRED.** Name of the geometry encoding format. Only `"WKB"` is supported. |
 | geometry_types | \[string]    | **REQUIRED.** The geometry types of all geometries, or an empty array if they are not known. |
-| crs            | object\|string\|null | [PROJJSON](https://proj.org/specifications/projjson.html) object, or an `<authority>:<code>` string (e.g. `"EPSG:4326"`), representing the Coordinate Reference System (CRS) of the geometry. The value MUST equal the Parquet logical-type `crs` property in the same form. If the field is not provided, the default CRS is [OGC:CRS84](https://www.opengis.net/def/crs/OGC/1.3/CRS84), which means the data in this column must be stored in longitude, latitude based on the WGS84 datum. |
+| crs            | object\|string | [PROJJSON](https://proj.org/specifications/projjson.html) object, or an `<authority>:<code>` string (e.g. `"EPSG:4326"`), representing the Coordinate Reference System (CRS) of the geometry. The value MUST equal the Parquet logical-type `crs` property in the same form. If the field is not provided, the default CRS is [OGC:CRS84](https://www.opengis.net/def/crs/OGC/1.3/CRS84), which means the data in this column must be stored in longitude, latitude based on the WGS84 datum. |
 | orientation    | string       | Winding order of exterior ring of polygons. If present must be `"counterclockwise"`; interior rings are wound in opposite order. If absent, no assertions are made regarding the winding order. |
 | edges          | string       | Describes how to interpret the edges of the geometries. Must be one of `planar`, `spherical`, `vincenty`, `thomas`, `andoyer`, `karney`. The default value is `planar`.
 | bbox           | \[number]    | Bounding Box of the geometries in the file, formatted according to [RFC 7946, section 5](https://tools.ietf.org/html/rfc7946#section-5). |
@@ -66,11 +66,11 @@ The CRS MAY be expressed in one of two forms:
 1. **Inline [PROJJSON](https://proj.org/specifications/projjson.html)** — a complete CRS definition, which is a JSON encoding of [WKT2:2019 / ISO-19162:2019](https://docs.opengeospatial.org/is/18-010r7/18-010r7.html), itself implementing the model of [OGC Topic 2: Referencing by coordinates abstract specification / ISO-19111:2019](http://docs.opengeospatial.org/as/18-005r4/18-005r4.html). This is the canonical form.
 2. **An `<authority>:<code>` string** — e.g. `"OGC:CRS84"`, `"EPSG:4326"`, `"EPSG:3857"`, `"IGNF:ATI"`. The authority and code MUST be one published by a recognized CRS authority (well-known authorities include OGC, EPSG, ESRI, and IGNF; see <https://spatialreference.org/> for an index).
 
-If the `crs` key does not exist, all coordinates in the geometries MUST use longitude, latitude based on the WGS84 datum, and the default value is [OGC:CRS84](https://www.opengis.net/def/crs/OGC/1.3/CRS84) for CRS-aware implementations. Note that a missing `crs` key has different meaning than a `crs` key set to `null` (see below).
+If the `crs` key does not exist, all coordinates in the geometries MUST use longitude, latitude based on the WGS84 datum, and the default value is [OGC:CRS84](https://www.opengis.net/def/crs/OGC/1.3/CRS84) for CRS-aware implementations.
 
 [OGC:CRS84](https://www.opengis.net/def/crs/OGC/1.3/CRS84) is equivalent to the well-known [EPSG:4326](https://epsg.org/crs_4326/WGS-84.html) but changes the axis from latitude-longitude to longitude-latitude. See below for additional details about representing or identifying OGC:CRS84, including when it arrives as an `<authority>:<code>` string rather than as PROJJSON.
 
-The value of this key may be explicitly set to `null` to indicate that there is no CRS assigned to this column (CRS is undefined or unknown). Because the Parquet core specification has no native way to express "no CRS" (an absent Parquet `crs` defaults to OGC:CRS84), a writer that sets the GeoParquet column-metadata `crs` to `null` MUST omit the Parquet logical-type `crs` property; the GeoParquet `null` is authoritative and overrides Parquet's default-to-OGC:CRS84 interpretation in this case.
+The GeoParquet 2.0 specification does not provide a way to indicate "no CRS" or "unknown CRS." A writer that does not know the CRS of its data SHOULD NOT write a GeoParquet 2.0 file; the `null` value permitted in GeoParquet 1.x is removed in 2.0 because the Parquet core specification has no native equivalent (an absent Parquet `crs` defaults to OGC:CRS84). Writers that need to express "unknown CRS" should use GeoParquet 1.x.
 
 ##### `crs` Parquet property
 
@@ -99,7 +99,6 @@ The GeoParquet column-metadata `crs` field and the Parquet logical-type `crs` pr
 | absent (Parquet default)                | absent                                     | OGC:CRS84                                     |
 | inline PROJJSON object                  | the same inline PROJJSON object            | CRS fully described in metadata               |
 | `<authority>:<code>` string             | the same `<authority>:<code>` string       | CRS identified by authority code              |
-| absent (writer signaling "no CRS")      | `null`                                     | CRS explicitly undefined / unknown            |
 
 The two fields MUST NOT disagree in form (one being PROJJSON while the other is `<authority>:<code>`) or in value.
 

--- a/format-specs/schema.json
+++ b/format-specs/schema.json
@@ -42,9 +42,6 @@
                   "type": "string",
                   "description": "An <authority>:<code> CRS reference (e.g. 'OGC:CRS84', 'EPSG:4326', 'EPSG:3857', 'IGNF:ATI').",
                   "pattern": "^[A-Za-z][A-Za-z0-9_-]*:[A-Za-z0-9_.-]+$"
-                },
-                {
-                  "type": "null"
                 }
               ]
             },

--- a/scripts/test_json_schema.py
+++ b/scripts/test_json_schema.py
@@ -156,11 +156,11 @@ metadata["columns"]["geometry"]["geometry_types"] = ["PointZ"]
 invalid_cases["geometry_type_z_missing_space"] = metadata
 
 
-# CRS - explicit null (kept in 2.0 pending separate `null`-deprecation discussion)
+# CRS - explicit null is no longer permitted in 2.0
 
 metadata = copy.deepcopy(metadata_template)
 metadata["columns"]["geometry"]["crs"] = None
-valid_cases["crs_null"] = metadata
+invalid_cases["crs_null"] = metadata
 
 # CRS - <authority>:<code> string (new in 2.0)
 


### PR DESCRIPTION
> **Stacked on #284.** This PR is based on the `crs-representation-2.0` branch from #284 and depends on it. Once #284 lands (or is rebased), this can be retargeted to `main`. Reviewing the diff against #284's branch shows only the null-specific changes.

## Goal

Open discussion on removing `null` as a permitted value of the GeoParquet column-metadata `crs` field in GeoParquet 2.0.

## Motivation

In GeoParquet 1.x, `crs: null` means "CRS is undefined or unknown" — distinct from "absent" (which defaults to OGC:CRS84).

In GeoParquet 2.0, the Parquet `GEOMETRY`/`GEOGRAPHY` logical-type `crs` property is the source of truth. The Parquet core specification has **no native way to express "no CRS / unknown CRS"** — absence defaults to OGC:CRS84. PR #284 (which this PR stacks on) preserves 1.x semantics by saying: if GeoParquet `crs: null`, the writer omits the Parquet `crs`, and the GeoParquet `null` is authoritative and overrides the Parquet default-to-OGC:CRS84. This works but adds a corner case to every reader's logic and a special row to the mirroring table.

## Proposed change

In GeoParquet 2.0:

- The column-metadata `crs` field MUST NOT be `null`.
- Permitted values are: a PROJJSON object, an `<authority>:<code>` string, or absent (defaulting to OGC:CRS84) — mirroring the Parquet logical-type `crs` exactly.

Writers that genuinely do not know the CRS of their data should continue to use GeoParquet 1.x.

## Trade-offs

### For disallowing `null`

- **Removes a special case.** Readers and writers each get one fewer branch. The mirroring rule between Parquet `crs` and GeoParquet `crs` becomes a literal equality check (and the mirroring table loses a row).
- **Honest about Parquet's model.** GeoParquet 2.0 is built on the Parquet logical type; pretending we have a richer null-aware model than Parquet does invites bugs at boundaries.
- **Few real users.** Production geospatial pipelines almost always know their CRS; "unknown CRS" is mostly an artifact of bad ingest tooling, and those tools can target 1.x.

### For keeping `null`

- **1.x compatibility.** Users migrating 1.x → 2.0 may have files with `crs: null` and expect the same semantics.
- **Real data has unknown CRS.** Legacy shapefiles without `.prj`, scraped data, OCR-derived geometry, intermediate processing steps — all real, all have undefined CRS.
- **Loss of expressiveness.** "Unknown" and "OGC:CRS84 (default)" are genuinely different facts about the data. Collapsing them silently can lead to wildly wrong analyses (treating projected coordinates as lon/lat).
- **The awkwardness is small.** One paragraph in the spec, one branch in writers. Not nothing, but not a lot either.

## Open questions

- Should 2.0 readers encountering a 1.x-style `null` reject the file, warn, or treat it as OGC:CRS84? (Affects migration paths.)
- Is there appetite to coordinate with the Parquet core spec to add a native "unknown CRS" sentinel, which would let GeoParquet keep `null` cleanly?
- If we keep `null` in 2.0, should we at least RECOMMEND that writers prefer either an explicit `<authority>:<code>` or omission, and use `null` only when truly necessary?

## Changes in this PR (relative to #284)

- `format-specs/schema.json`: remove the `{"type": "null"}` clause from the `crs` `oneOf`.
- `format-specs/geoparquet.md`:
  - Column-metadata `crs` type: `object|string|null` → `object|string`.
  - Replace the `null` paragraph in §`crs` with a short paragraph explaining that 2.0 has no "unknown CRS" form and directing such writers to GeoParquet 1.x.
  - Remove the `null` row from the mirroring table.
- `scripts/test_json_schema.py`: flip `crs_null` from a valid to an invalid case.

```
57 passed in 0.5s  (test_json_schema.py)
72 passed in 2.1s  (full scripts/ test suite)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)