### PR TITLE
Add zstd compression to example storing GeoParquet with sedona

### DIFF
--- a/format-specs/distributing-geoparquet.md
+++ b/format-specs/distributing-geoparquet.md
@@ -334,7 +334,7 @@ df_partitioned = (
 # Write in parallel directly from each executor node.
 # There are several options for geoparquet writing:
 # https://sedona.apache.org/latest/tutorial/files/geoparquet-sedona-spark/
-df_partitioned.write.format("geoparquet").mode("overwrite").save(
+df_partitioned.write.format("geoparquet").mode("overwrite").option("compression", "zstd").save(
     "buildings_partitioned"
 )
 


### PR DESCRIPTION
The text in the changed README suggests to use zstd compression. The example at the bottom, where Sedona stores a GeoParquet, the zstd is not explicitly set. I learned in this [thread](https://github.com/apache/sedona/discussions/3109), that zstd compression can be set using `option`. I tested it and it works! This PR adapts the example accordingly. 