### PR TITLE
Add Geomermaids OSM daily exports to distribution examples

### DIFF
--- a/format-specs/distributing-geoparquet.md
+++ b/format-specs/distributing-geoparquet.md
@@ -170,6 +170,7 @@ splits larger countries into smaller files, using S2 cells.
 Wherobots.
 - [Planet Ag Field Boundaries over EU](https://source.coop/repositories/planet/eu-field-boundaries/description) - needs to be
 spatially partitioned, row group size is 25,000.
+- [Geomermaids OSM daily exports](https://parquetry.geomermaids.com/) - GeoParquet v2.0 OSM exports with Hilbert sorting and partitioning.
 
 ## Tool Examples
 


### PR DESCRIPTION
Adds the Geomermaids OSM daily exports to the list of GeoParquet data distribution examples in `distributing-geoparquet.md`.

These are daily OpenStreetMap exports published as GeoParquet v2.0, with Hilbert sorting and spatial partitioning, hosted at https://parquetry.geomermaids.com/. They serve as a real-world example of the distribution best practices described in this document.