### PR TITLE
Remove stale 2D+M bbox text from schema.json

### DIFF
--- a/format-specs/schema.json
+++ b/format-specs/schema.json
@@ -63,7 +63,7 @@
                   "maxItems": 4
                 },
                 {
-                  "description": "3D bbox consisting of (xmin, ymin, zmin, xmax, ymax, zmax) or 2D+M bbox (xmin, ymin, mmin, xmax, ymax, mmax)",
+                  "description": "3D bbox consisting of (xmin, ymin, zmin, xmax, ymax, zmax)",
                   "minItems": 6,
                   "maxItems": 6
                 },


### PR DESCRIPTION
PR #278 removed the 6-element XYM bbox from the prose (c83f2e9), but the schema.json description of the 6-element form still says "or 2D+M bbox". This aligns the schema description with the prose: 6 elements always mean XYZ.

Fixes #300.